### PR TITLE
fix: primary color 지정한 이후 기존의 tailwind색이 적용 안되는 문제 해결

### DIFF
--- a/apps/client/tailwind.config.js
+++ b/apps/client/tailwind.config.js
@@ -1,15 +1,10 @@
+const sharedConfig = require('@jjoing/ui/tailwind.config.js');
+
 /** @type {import('tailwindcss').Config} */
-
-const commonConfig = require('@jjoing/ui/tailwind.config.js');
-
 module.exports = {
-  ...commonConfig,
+  ...sharedConfig,
   content: [
     './src/**/*.{js,jsx,ts,tsx}',
     './node_modules/@jjoing/ui/src/**/*.{js,jsx,ts,tsx}',
   ],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
 };

--- a/packages/ui/src/Spinner/index.tsx
+++ b/packages/ui/src/Spinner/index.tsx
@@ -7,13 +7,13 @@ type SpinnerProps = {
 };
 
 const SpinnerVariants = cva(
-  'animate-spin rounded-full border-solid border-gray-500 border-t-primary',
+  'animate-spin rounded-full border-solid border-gray-300 border-t-primary',
   {
     variants: {
       size: {
-        lg: 'size-16 border-8',
-        md: 'size-12 border-[6px]',
-        sm: 'size-8 border-4',
+        lg: 'size-12 border-2',
+        md: 'size-10 border-2',
+        sm: 'size-8 border-2',
       },
     },
     defaultVariants: {

--- a/packages/ui/tailwind.config.js
+++ b/packages/ui/tailwind.config.js
@@ -2,8 +2,10 @@
 module.exports = {
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
   theme: {
-    colors: {
-      primary: '#38B57D',
+    extend: {
+      colors: {
+        primary: '#38B57D',
+      },
     },
   },
   plugins: [],

--- a/storybook/tailwind.config.cjs
+++ b/storybook/tailwind.config.cjs
@@ -1,13 +1,10 @@
+const sharedConfig = require('@jjoing/ui/tailwind.config.js');
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  ...sharedConfig,
   content: [
     './node_modules/@jjoing/ui/src/**/*.{js,jsx,ts,tsx}',
     './src/**/*.{js,jsx,ts,tsx}',
   ],
-  theme: {
-    colors: {
-      primary: '#38B57D',
-    },
-  },
-  plugins: [],
 };


### PR DESCRIPTION
tailwind color을 내보내기 할때 `extend: { color: { ... }}`를 사용하여 tailwindCss의 기본 색상 팔레트가 덮어씌워져서 사라지는 문제를 해결하였음